### PR TITLE
Handle Android 17 background audio hardening for sound tile

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
 
     <application
@@ -55,6 +57,15 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
+        </service>
+
+        <service
+            android:name="com.alftendev.simplesoundquicksettings.services.SoundModeChangeService"
+            android:exported="false"
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="User-initiated sound mode change from a Quick Settings tile" />
         </service>
     </application>
 

--- a/app/src/main/java/com/alftendev/simplesoundquicksettings/services/SoundModeChangeService.kt
+++ b/app/src/main/java/com/alftendev/simplesoundquicksettings/services/SoundModeChangeService.kt
@@ -1,0 +1,122 @@
+package com.alftendev.simplesoundquicksettings.services
+
+import android.annotation.SuppressLint
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.ComponentName
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.media.AudioManager
+import android.os.Build
+import android.os.IBinder
+import android.service.quicksettings.TileService
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
+import com.alftendev.simplesoundquicksettings.MainActivity
+import com.alftendev.simplesoundquicksettings.R
+import com.alftendev.simplesoundquicksettings.utils.Utils
+
+class SoundModeChangeService : Service() {
+
+    companion object {
+        private const val CHANNEL_ID = "sound_mode_changes"
+        private const val NOTIFICATION_ID = 1
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        startInForeground()
+
+        try {
+            if (Utils.isDoNotDisturbPermissionGranted(this)) {
+                changeSoundMode()
+            }
+
+            TileService.requestListeningState(
+                this,
+                ComponentName(this, SoundTile::class.java)
+            )
+        } finally {
+            stopForeground(STOP_FOREGROUND_REMOVE)
+            stopSelf(startId)
+        }
+
+        return START_NOT_STICKY
+    }
+
+    // AGP 8.13 does not associate the specialUse type with this service, even
+    // though the merged and packaged manifests retain the declaration.
+    @SuppressLint("ForegroundServiceType")
+    private fun startInForeground() {
+        createNotificationChannel()
+        val notification = createNotification()
+
+        val foregroundServiceType =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
+            } else {
+                0
+            }
+
+        ServiceCompat.startForeground(
+            this,
+            NOTIFICATION_ID,
+            notification,
+            foregroundServiceType
+        )
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return
+        }
+
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            getString(R.string.sound_mode_notification_channel),
+            NotificationManager.IMPORTANCE_LOW
+        )
+        getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+    }
+
+    private fun createNotification(): Notification {
+        val openAppIntent = PendingIntent.getActivity(
+            this,
+            0,
+            Intent(this, MainActivity::class.java),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.baseline_notifications_active_24)
+            .setContentTitle(getString(R.string.app_name))
+            .setContentText(getString(R.string.sound_mode_notification_text))
+            .setContentIntent(openAppIntent)
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setOngoing(true)
+            .setSilent(true)
+            .build()
+    }
+
+    private fun changeSoundMode() {
+        val audio = getSystemService(AUDIO_SERVICE) as AudioManager
+
+        audio.ringerMode = when (audio.ringerMode) {
+            AudioManager.RINGER_MODE_NORMAL -> AudioManager.RINGER_MODE_VIBRATE
+
+            AudioManager.RINGER_MODE_VIBRATE -> {
+                audio.ringerMode = AudioManager.RINGER_MODE_NORMAL
+                AudioManager.RINGER_MODE_SILENT
+            }
+
+            AudioManager.RINGER_MODE_SILENT -> AudioManager.RINGER_MODE_NORMAL
+
+            else -> return
+        }
+    }
+}

--- a/app/src/main/java/com/alftendev/simplesoundquicksettings/services/SoundTile.kt
+++ b/app/src/main/java/com/alftendev/simplesoundquicksettings/services/SoundTile.kt
@@ -8,11 +8,14 @@ import android.graphics.drawable.Icon
 import android.media.AudioManager
 import android.service.quicksettings.Tile
 import android.service.quicksettings.TileService
+import androidx.core.content.ContextCompat
 import com.alftendev.simplesoundquicksettings.R
 import com.alftendev.simplesoundquicksettings.utils.ImageUtils.getSoundStateDrawable
 import com.alftendev.simplesoundquicksettings.utils.Utils
 
 class SoundTile : TileService() {
+
+    private var receiverRegistered = false
 
     private val broadcastReceiver: BroadcastReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
@@ -64,31 +67,25 @@ class SoundTile : TileService() {
             return
         }
 
-        val audio = getSystemService(AUDIO_SERVICE) as AudioManager
-
-        audio.ringerMode = when (audio.ringerMode) {
-            AudioManager.RINGER_MODE_NORMAL -> AudioManager.RINGER_MODE_VIBRATE
-
-            AudioManager.RINGER_MODE_VIBRATE -> {
-                audio.ringerMode = AudioManager.RINGER_MODE_NORMAL
-                AudioManager.RINGER_MODE_SILENT
-            }
-
-            AudioManager.RINGER_MODE_SILENT -> AudioManager.RINGER_MODE_NORMAL
-
-            else -> {
-                return
-            }
-        }
-
-        updateSoundTile()
+        ContextCompat.startForegroundService(
+            this,
+            Intent(this, SoundModeChangeService::class.java)
+        )
     }
 
     override fun onStartListening() {
         super.onStartListening()
 
-        val filter = IntentFilter(AudioManager.RINGER_MODE_CHANGED_ACTION)
-        registerReceiver(broadcastReceiver, filter)
+        if (!receiverRegistered) {
+            val filter = IntentFilter(AudioManager.RINGER_MODE_CHANGED_ACTION)
+            ContextCompat.registerReceiver(
+                this,
+                broadcastReceiver,
+                filter,
+                ContextCompat.RECEIVER_NOT_EXPORTED
+            )
+            receiverRegistered = true
+        }
 
         updateSoundTile()
     }
@@ -96,10 +93,12 @@ class SoundTile : TileService() {
     override fun onStopListening() {
         super.onStopListening()
 
-        try {
-            unregisterReceiver(broadcastReceiver)
-        } catch (e: Exception) {
-            e.printStackTrace()
+        if (receiverRegistered) {
+            try {
+                unregisterReceiver(broadcastReceiver)
+            } finally {
+                receiverRegistered = false
+            }
         }
     }
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -9,4 +9,6 @@
 
     <string name="toast_text">Concede el permiso a la aplicación para poder usarla</string>
     <string name="settings">Ajustes</string>
+    <string name="sound_mode_notification_channel">Cambios del modo de sonido</string>
+    <string name="sound_mode_notification_text">Cambiando el modo de sonido</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -7,4 +7,6 @@
     <string name="not_completed">Per poter funzionare, l\'app ha bisogno dell\'autorizzazione a modificare la modalità Non disturbare.</string>
     <string name="toast_text">Concedere all\'app il permesso di utilizzarla</string>
     <string name="settings">Impostazioni</string>
+    <string name="sound_mode_notification_channel">Modifiche alla modalità audio</string>
+    <string name="sound_mode_notification_text">Modifica della modalità audio</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,4 +11,6 @@
 
     <string name="toast_text">Grant the app permission to use it</string>
     <string name="settings">Settings</string>
+    <string name="sound_mode_notification_channel">Sound mode changes</string>
+    <string name="sound_mode_notification_text">Changing the sound mode</string>
 </resources>


### PR DESCRIPTION
Fixes #7
Fixes #10

## Root cause

Android 17 introduces [background audio hardening](https://developer.android.com/about/versions/17/changes/bg-audio). `AudioManager.setRingerMode()` is silently ignored when the app has neither a visible activity nor a qualifying foreground service.

This matches the reported behavior: sound changes work while the app is visible, the tile works briefly while the process retains foreground state, and then tile taps stop changing the ringer after the app returns to the background. Cached-process freezing can appear in logs, but it is not the direct failure mechanism.

## Changes

- perform the user-initiated ringer change in a one-shot `specialUse` foreground service
- start that service directly from the Quick Settings tile tap and stop it immediately afterward
- request a tile-state refresh after the operation
- register the ringer receiver through `ContextCompat` with a balanced lifecycle
- add the required foreground-service permissions, subtype declaration, notification, and translations

The foreground-service subtype is documented in the manifest as: `User-initiated sound mode change from a Quick Settings tile`.

## Verification

- retained production commit: `8bd99f6a4e52cdbf87a95801eed2829c4ea8689d`
- the retained production code passed unit tests, Android Lint, manifest merge, and debug assembly in [this validation run](https://github.com/zzlatev-openclaw-neo/sound-quick-settings/actions/runs/30190179671) before the test-only CI/package scaffolding was removed from the PR
- preliminary Pixel Android 17 device testing is working
- a 1–2 day soak test remains in progress before marking the PR ready for review
